### PR TITLE
fix caret position problem

### DIFF
--- a/src/com/blogspot/cdcsutils/lognote/LogTable.kt
+++ b/src/com/blogspot/cdcsutils/lognote/LogTable.kt
@@ -533,6 +533,9 @@ open class LogTable(tableModel:LogTableModel) : JTable(tableModel){
 
         for (row in rows) {
             value = getLogText(row)
+            if (row == targetRow) {
+                caretPos = log.length - value.length
+            }
             if (isPlaneText) {
                 if (log.isEmpty()) {
                     log.append(value)


### PR DESCRIPTION
In [893d5b5](https://github.com/M1nt-Ch0c0/lognote/commit/893d5b5090b5bbcaf71c2a59d9b5fda5edacf1e9) I saw a change of  `getSelectedLog` function.  But you possibly forget to assign the `caretPos` variable, which actually becomes an constant zero value.