### PR TITLE
multiple environment variables prevents config

### DIFF
--- a/src/com/blogspot/cdcsutils/lognote/ConfigManager.kt
+++ b/src/com/blogspot/cdcsutils/lognote/ConfigManager.kt
@@ -120,11 +120,33 @@ class ConfigManager private constructor() {
     private var mConfigPath = CONFIG_FILE
 
     init {
-        if (LOGNOTE_HOME.isNotEmpty()) {
-            mConfigPath = "$LOGNOTE_HOME${File.separator}$CONFIG_FILE"
-        }
+        mConfigPath = initializeConfigPath()
         Utils.printlnLog("Config Path : $mConfigPath")
         manageVersion()
+    }
+
+    private fun initializeConfigPath(): String {
+        val osType = Utils.getOSType()
+        if(LOGNOTE_HOME.isEmpty()) {
+            return mConfigPath
+        }
+
+        // Windows OS and multiple entries in environment variables table
+        if(osType.contains("windows") && LOGNOTE_HOME.contains(";")) {
+            val firstPathExists = LOGNOTE_HOME
+                .split(";")
+                .filter(String::isNotEmpty)
+                .firstOrNull(Utils::pathExists)
+
+            return if(firstPathExists != null) {
+                "$firstPathExists${File.separator}$CONFIG_FILE"
+            } else { // No valid path found same as empty LOGNOTE_HOME
+                mConfigPath
+            }
+        }
+
+        // Default behaviour
+        return "${LOGNOTE_HOME}${File.separator}$CONFIG_FILE"
     }
 
     private fun setDefaultConfig() {

--- a/src/com/blogspot/cdcsutils/lognote/ConfigManager.kt
+++ b/src/com/blogspot/cdcsutils/lognote/ConfigManager.kt
@@ -1,5 +1,6 @@
 package com.blogspot.cdcsutils.lognote
 
+import com.formdev.flatlaf.util.SystemInfo
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
@@ -114,39 +115,38 @@ class ConfigManager private constructor() {
         fun getInstance(): ConfigManager {
             return mInstance
         }
+
+        fun getHomePath(fileName: String): String {
+            if(LOGNOTE_HOME.isEmpty()) {
+                return fileName
+            }
+
+            // Windows OS and multiple entries in environment variables table
+            if(SystemInfo.isWindows) {
+                val firstPathExists = LOGNOTE_HOME
+                    .split(";")
+                    .filter(String::isNotEmpty)
+                    .firstOrNull(Utils::pathExists)
+
+                return if(firstPathExists != null) {
+                    "$firstPathExists${File.separator}$fileName"
+                } else { // No valid path found same as empty LOGNOTE_HOME
+                    fileName
+                }
+            }
+
+            // Default behaviour
+            return "${LOGNOTE_HOME}${File.separator}$fileName"
+        }
     }
 
     private val mProperties = Properties()
     private var mConfigPath = CONFIG_FILE
 
     init {
-        mConfigPath = initializeConfigPath()
+        mConfigPath = getHomePath(CONFIG_FILE)
         Utils.printlnLog("Config Path : $mConfigPath")
         manageVersion()
-    }
-
-    private fun initializeConfigPath(): String {
-        val osType = Utils.getOSType()
-        if(LOGNOTE_HOME.isEmpty()) {
-            return mConfigPath
-        }
-
-        // Windows OS and multiple entries in environment variables table
-        if(osType.contains("windows") && LOGNOTE_HOME.contains(";")) {
-            val firstPathExists = LOGNOTE_HOME
-                .split(";")
-                .filter(String::isNotEmpty)
-                .firstOrNull(Utils::pathExists)
-
-            return if(firstPathExists != null) {
-                "$firstPathExists${File.separator}$CONFIG_FILE"
-            } else { // No valid path found same as empty LOGNOTE_HOME
-                mConfigPath
-            }
-        }
-
-        // Default behaviour
-        return "${LOGNOTE_HOME}${File.separator}$CONFIG_FILE"
     }
 
     private fun setDefaultConfig() {

--- a/src/com/blogspot/cdcsutils/lognote/PropertiesBase.kt
+++ b/src/com/blogspot/cdcsutils/lognote/PropertiesBase.kt
@@ -1,48 +1,18 @@
 package com.blogspot.cdcsutils.lognote
 
-import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
 import java.io.IOException
 import java.util.*
 
 abstract class PropertiesBase(fileName: String) {
-    companion object {
-        val LOGNOTE_HOME: String = System.getenv("LOGNOTE_HOME") ?: ""
-    }
-
     protected val mProperties = Properties()
     private var mXmlPath = fileName
 
     init {
-        mXmlPath = initializeXmlPath()
+        mXmlPath = ConfigManager.getHomePath(fileName)
         Utils.printlnLog("Xml File Path : $mXmlPath")
     }
-
-    private fun initializeXmlPath(): String {
-        val osType = Utils.getOSType()
-        if(LOGNOTE_HOME.isEmpty()) {
-            return mXmlPath
-        }
-
-        // Windows OS and multiple entries in environment variables table
-        if(osType.contains("windows") && LOGNOTE_HOME.contains(";")) {
-            val firstPathExists = LOGNOTE_HOME
-                .split(";")
-                .filter(String::isNotEmpty)
-                .firstOrNull(Utils::pathExists)
-
-            return if(firstPathExists != null) {
-                "$firstPathExists${File.separator}$mXmlPath"
-            } else { // No valid path found same as empty LOGNOTE_HOME
-                mXmlPath
-            }
-        }
-
-        // Default behaviour
-        return "$LOGNOTE_HOME${File.separator}$mXmlPath"
-    }
-
 
     protected fun loadXml(): Boolean {
         var ret = true

--- a/src/com/blogspot/cdcsutils/lognote/PropertiesBase.kt
+++ b/src/com/blogspot/cdcsutils/lognote/PropertiesBase.kt
@@ -15,11 +15,34 @@ abstract class PropertiesBase(fileName: String) {
     private var mXmlPath = fileName
 
     init {
-        if (LOGNOTE_HOME.isNotEmpty()) {
-            mXmlPath = "$LOGNOTE_HOME${File.separator}$mXmlPath"
-        }
+        mXmlPath = initializeXmlPath()
         Utils.printlnLog("Xml File Path : $mXmlPath")
     }
+
+    private fun initializeXmlPath(): String {
+        val osType = Utils.getOSType()
+        if(LOGNOTE_HOME.isEmpty()) {
+            return mXmlPath
+        }
+
+        // Windows OS and multiple entries in environment variables table
+        if(osType.contains("windows") && LOGNOTE_HOME.contains(";")) {
+            val firstPathExists = LOGNOTE_HOME
+                .split(";")
+                .filter(String::isNotEmpty)
+                .firstOrNull(Utils::pathExists)
+
+            return if(firstPathExists != null) {
+                "$firstPathExists${File.separator}$mXmlPath"
+            } else { // No valid path found same as empty LOGNOTE_HOME
+                mXmlPath
+            }
+        }
+
+        // Default behaviour
+        return "$LOGNOTE_HOME${File.separator}$mXmlPath"
+    }
+
 
     protected fun loadXml(): Boolean {
         var ret = true

--- a/src/com/blogspot/cdcsutils/lognote/Utils.kt
+++ b/src/com/blogspot/cdcsutils/lognote/Utils.kt
@@ -9,9 +9,12 @@ import java.io.InputStreamReader
 import java.lang.management.ManagementFactory
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
+import java.util.Locale
 import java.util.regex.Pattern
 import javax.swing.*
 import javax.swing.border.AbstractBorder
+import kotlin.io.path.Path
+import kotlin.io.path.exists
 import kotlin.system.exitProcess
 
 
@@ -204,6 +207,21 @@ class Utils {
             }
 
             return pattern
+        }
+
+        fun getOSType(): String {
+            return try {
+                // Get OS type if allowed
+                System.getProperty("os.name")
+                    .lowercase(Locale.ENGLISH)
+            } catch(ex: SecurityException) {
+                ex.printStackTrace()
+                ""
+            }
+        }
+
+        fun pathExists(path: String): Boolean {
+            return Path(path).exists()
         }
     }
 

--- a/src/com/blogspot/cdcsutils/lognote/Utils.kt
+++ b/src/com/blogspot/cdcsutils/lognote/Utils.kt
@@ -209,17 +209,6 @@ class Utils {
             return pattern
         }
 
-        fun getOSType(): String {
-            return try {
-                // Get OS type if allowed
-                System.getProperty("os.name")
-                    .lowercase(Locale.ENGLISH)
-            } catch(ex: SecurityException) {
-                ex.printStackTrace()
-                ""
-            }
-        }
-
         fun pathExists(path: String): Boolean {
             return Path(path).exists()
         }


### PR DESCRIPTION
Fixes bug where the use of multiple environment variable entries for LOGNOTE_HOME or having a trailing semicolon in the path prevents config from loading on windows operating system.

Due to the consideration of multiple entries under the same Environment Variable Key, the behaviour under windows OS is now  proposed to select the first defined environment variable path that is valid or default to the original behaviour if no valid paths are defined or found.

Testing:
For each of the following combinations, clearing config then changing theme with restart will save theme as expected:
- No environment variable specified
- Environment variable with no entries
- Single entry 
- Single entry with trailing semicolon
- Single invalid entry 
- Three entries: one invalid and two valid with invalid placed above the two valid